### PR TITLE
Give User the ability to toggle containerName and namespace of cert-manager

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -11,7 +11,7 @@
     dashboards: {
       enableMultiCluster: false,
       clusterVariableSelector: '',
-      containerName: 'cert-manager-controller',
+      containerName: 'cert-manager',
       namespace: 'cert-manager',
 
       defaultSelector: if self.enableMultiCluster then 'cluster="$cluster"' else '',

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -15,8 +15,8 @@
       containerNamespace: 'cert-manager',
 
       defaultSelector: if self.enableMultiCluster then 'cluster="$cluster"' else '',
-      containerSelector: 'container=%s' % self.containerName + if self.enableMultiCluster then ',cluster="$cluster"' else '',
-      namespaceSelector: 'namespace=%s' % self.containerNamespace + if self.enableMultiCluster then ',cluster="$cluster"' else '',
+      containerSelector: 'container="%s"' % self.containerName + if self.enableMultiCluster then ',cluster="$cluster"' else '',
+      namespaceSelector: 'namespace="%s"' % self.containerNamespace + if self.enableMultiCluster then ',cluster="$cluster"' else '',
 
       certmanagerCertificateReadyStatusSelector: self.defaultSelector,
       certmanagerCertificateExpirationTimestampSecondsSelector: self.defaultSelector,

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -11,10 +11,12 @@
     dashboards: {
       enableMultiCluster: false,
       clusterVariableSelector: '',
+      containerName: 'cert-manager-controller',
+      containerNamespace: 'cert-manager',
 
       defaultSelector: if self.enableMultiCluster then 'cluster="$cluster"' else '',
-      containerSelector: if self.enableMultiCluster then 'container="cert-manager", cluster="$cluster"' else 'container="cert-manager"',
-      namespaceSelector: if self.enableMultiCluster then 'namespace="cert-manager", cluster="$cluster"' else 'namespace="cert-manager"',
+      containerSelector: 'container=%s' % self.containerName + if self.enableMultiCluster then ',cluster="$cluster"' else '',
+      namespaceSelector: 'namespace=%s' % self.containerNamespace + if self.enableMultiCluster then ',cluster="$cluster"' else '',
 
       certmanagerCertificateReadyStatusSelector: self.defaultSelector,
       certmanagerCertificateExpirationTimestampSecondsSelector: self.defaultSelector,

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -12,11 +12,11 @@
       enableMultiCluster: false,
       clusterVariableSelector: '',
       containerName: 'cert-manager-controller',
-      containerNamespace: 'cert-manager',
+      namespace: 'cert-manager',
 
       defaultSelector: if self.enableMultiCluster then 'cluster="$cluster"' else '',
       containerSelector: 'container="%s"' % self.containerName + if self.enableMultiCluster then ',cluster="$cluster"' else '',
-      namespaceSelector: 'namespace="%s"' % self.containerNamespace + if self.enableMultiCluster then ',cluster="$cluster"' else '',
+      namespaceSelector: 'namespace="%s"' % self.namespace + if self.enableMultiCluster then ',cluster="$cluster"' else '',
 
       certmanagerCertificateReadyStatusSelector: self.defaultSelector,
       certmanagerCertificateExpirationTimestampSecondsSelector: self.defaultSelector,


### PR DESCRIPTION
This commit gives user the ability to set the containerName and containerNamespace in cert-manager and the current containerName of the cert-manager in the pod seems to cert-manager-controller.

![image](https://github.com/user-attachments/assets/973589ed-bdb2-4d4e-99b0-51bcca8a8b55)
![image](https://github.com/user-attachments/assets/4e5b68c3-dbbd-48c8-b3b4-25f0b6a1c27f)
![image](https://github.com/user-attachments/assets/d6324716-f4c1-457a-92b8-13cd7a8a559c)
